### PR TITLE
Fix ExecuteCommand.php

### DIFF
--- a/Command/ExecuteCommand.php
+++ b/Command/ExecuteCommand.php
@@ -193,7 +193,7 @@ HELP
             $progress->finish();
 
 
-            if(!is_a($this->output, StreamOutput::class))
+            if (method_exists($sectionProgressbar, 'clear'))
             {$sectionProgressbar->clear();}
 
             $io->section('Finished Executions');


### PR DESCRIPTION
When starting the command schedule:start without -v the output will be NullOutput which doesn't contain the clear function